### PR TITLE
add StopSplitter example

### DIFF
--- a/1-tutorials/6-splitting-trajectories.ipynb
+++ b/1-tutorials/6-splitting-trajectories.ipynb
@@ -81,6 +81,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Split the trajectory where then are no observations for at least two minutes:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -127,12 +134,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Split the trajectory where observation stay within 30 CRS units for at least 1 minute. Discard created trajectories that are shorter than 500 CRS units long:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "split = mpd.StopSplitter(my_traj).split(min_duration=timedelta(minutes=1), max_diameter=30, min_length=500)\n",
+    "split = mpd.StopSplitter(my_traj).split(max_diameter=30, min_duration=timedelta(minutes=1), min_length=500)\n",
     "split"
    ]
   },
@@ -157,11 +171,59 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## SpeedSplitter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "help(mpd.SpeedSplitter)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Split the trajectory where the speed is below one CRS unit for at least five minutes:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "split = mpd.SpeedSplitter(my_traj).split(speed=1, duration=timedelta(minutes=5))\n",
+    "split"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "split.to_traj_gdf()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = plt.subplots(nrows=1, ncols=len(split), figsize=(19,4))\n",
+    "for i, traj in enumerate(split):\n",
+    "    traj.plot(ax=axes[i], linewidth=5.0, capstyle='round', column='speed', vmax=20)"
+   ]
   }
  ],
  "metadata": {
@@ -180,7 +242,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.12"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/1-tutorials/6-splitting-trajectories.ipynb
+++ b/1-tutorials/6-splitting-trajectories.ipynb
@@ -137,7 +137,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Split the trajectory where observation stay within 30 CRS units for at least 1 minute. Discard created trajectories that are shorter than 500 CRS units long:"
+    "Split the trajectory where observations stay within 30 meters for at least 1 minute. Discard created trajectories that are shorter than 500 meters long:"
    ]
   },
   {
@@ -192,7 +192,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Split the trajectory where the speed is below one CRS unit for at least five minutes:"
+    "Split the trajectory where the speed is below one meters per second for at least five minutes:"
    ]
   },
   {


### PR DESCRIPTION
notebook diff renders aren't great. Can add https://www.reviewnb.com/ to the repo here to help with this.

Otherwise, take a look at source (https://github.com/raybellwaves/movingpandas-examples/blob/SpeedSplitter-ex/1-tutorials/6-splitting-trajectories.ipynb) and you can run the binder to test if you like (https://mybinder.org/v2/gh/anitagraser/movingpandas-examples/main?filepath=1-tutorials/6-splitting-trajectories.ipynb).

I added a sentence between each splitter. Happy to have feedback there. I've added them below as well:

 - ObservationGapSplitter: Split the trajectory where then are no observations for at least two minutes
 - StopSplitter: Split the trajectory where observation stay within 30 CRS units for at least 1 minute. Discard created trajectories that are shorter than 500 CRS units long
 - SpeedSplitter: Split the trajectory where the speed is below one CRS unit for at least five minutes